### PR TITLE
Tiny patch to add color for color terminal users, they used to get meaningless XX before every line.

### DIFF
--- a/base.vim
+++ b/base.vim
@@ -21,15 +21,15 @@ show_complexity()
 END
 " no idea why it is needed to update colors each time
 " to actually see the colors
-hi low_complexity guifg=#004400 guibg=#004400
-hi medium_complexity guifg=#bbbb00 guibg=#bbbb00
-hi high_complexity guifg=#ff2222 guibg=#ff2222
+hi low_complexity guifg=#004400 guibg=#004400 ctermfg=2 ctermbg=2
+hi medium_complexity guifg=#bbbb00 guibg=#bbbb00 ctermfg=3 ctermbg=3
+hi high_complexity guifg=#ff2222 guibg=#ff2222 ctermfg=1 ctermbg=1
 endfunction
 
 hi SignColumn guifg=fg guibg=bg
-hi low_complexity guifg=#004400 guibg=#004400
-hi medium_complexity guifg=#bbbb00 guibg=#bbbb00
-hi high_complexity guifg=#ff2222 guibg=#ff2222
+hi low_complexity guifg=#004400 guibg=#004400 ctermfg=2 ctermbg=2
+hi medium_complexity guifg=#bbbb00 guibg=#bbbb00 ctermfg=3 ctermbg=3
+hi high_complexity guifg=#ff2222 guibg=#ff2222 ctermfg=1 ctermbg=1
 sign define low_complexity text=XX texthl=low_complexity
 sign define medium_complexity text=XX texthl=medium_complexity
 sign define high_complexity text=XX texthl=high_complexity


### PR DESCRIPTION
Using ANSI colornumbers, too lazy to generalize for all different cterms.
This works for me. And real generalization would make these configuration
options anyway, to cater for the colorblind too.
